### PR TITLE
Add components to server image

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TAG=latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pki/certs
 emails/*.eml
+*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 pki/certs
 emails/*.eml
 *.dll
+components/
+!components/*.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo allows you to run CluedIn locally using Docker
 ## Requirements
 
 - Windows version **1903** or greater
-- Latest version of [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) (> 19.03.2)
+- Latest version of [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) (> 19.03.4)
 - Docker [experimental features](https://docs.docker.com/docker-for-windows/#daemon) turned on 
 - Docker set up to run [Windows containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers)
 - Access to the private repositories inside the  [cluedin](https://hub.docker.com/u/cluedin/) DockerHub organization. You will require a Docker Hub account and request access from CluedIn; then use this account to do a ```docker login```.
@@ -50,7 +50,7 @@ The CluedIn server component takes a while to boot up. You can verify it is star
 docker-compose logs -f server
 ```
 
-The server will be ready when you see the message `Server Started`. Open your browser and the CluedIn should be available under [https://app.127.0.0.1.xip.io](https://app.127.0.0.1.xip.io).
+The server will be ready when you see the message `Server Started`. Open your browser and CluedIn should be available under [https://app.127.0.0.1.xip.io](https://app.127.0.0.1.xip.io).
 
 In order to use CluedIn you need to create an *organization*. There are two ways to do this
 
@@ -73,13 +73,20 @@ In order to use CluedIn you need to create an *organization*. There are two ways
     1. Fill in the information and click in *Sign up*
     1. You will be redirected to the login screen. Simply add the information created in the step above.
 
+## Adding extra components
+
+You can add extra providers or enrichers in two different ways:
+
+1. Add a a file named `Packages.txt` in the `./components` folder with the names of the nuget packages for the components you want to install. If the Nuget packages are not available publicly, add a `KEY` environment variable with the token to access the Nuget feed.
+1. Copy the relevant DLLs for the components in the `./components` folder.
+
 ## Removal
 
 You can then stop and start the stack, using the usual docker-compose commands
 
 ```
-docker-compose stop # containers are turned off, state is maintained
-docker-compose down # containers are removed, state is lost
+docker-compose down # containers are removed, data is kept 
+docker-compose down -v # containers are removed and data is lost
 ```
 
 You can remove the certificates running

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ In order to use CluedIn you need to create an *organization*. There are two ways
 
 You can add extra providers or enrichers in two different ways:
 
-1. Add a a file named `Packages.txt` in the `./components` folder with the names of the nuget packages for the components you want to install. If the Nuget packages are not available publicly, add a `KEY` environment variable with the token to access the Nuget feed.
+1. Via Nuget packages
+    1. Add a a file named `Packages.txt` in the `./components` folder with the names of the nuget packages for the components you want to install.
+    1. If the Nuget packages are not available publicly add a `nuget.config` file in the `./components` folder. Either pass the password token to the nuget.config or create a `KEY` environment variable with it.
 1. Copy the relevant DLLs for the components in the `./components` folder.
 
 ## Removal

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,2 @@
+DLL files added here will get copied to the Cluedin.Server image
+Alternatively add 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
     ports:
     - "9200:9200"
     - "9300:9300"
+    volumes:
+    - elasticsearch:/usr/share/elasticsearch/data
 
   sqlserver:
     image: cluedin/sqlserver:${TAG}
@@ -126,3 +128,4 @@ services:
 
 volumes:
   sqlserver:
+  elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     environment:
     - NEO4J_AUTH=none
     - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+    - NEO4J_EDITION=community
     ports:
     - "7474:7474"
     - "7687:7687"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,9 @@ services:
     - "5672:5672"
     - "15672:15672"
     hostname: cluedin-dev
+    environment: 
+    - RABBITMQ_VM_MEMORY_HIGH_WATERMARK=0.95
+    - RABBITMQ_LOOPBACK_USERS=none
 
   redis:
     image: redis:5.0-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,12 @@ services:
     - EmailSender=app@cluedin-test.online
     - EmailUserName
     - EmailPassword
+    - KEY
     ports:
     - "9000:9000"
     - "9001:9001"
+    volumes:
+    - ./components:c:\components
     depends_on:
     - sqlserver
     - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   server:
-    image: cluedin/cluedin-server
+    image: cluedin/cluedin-server:${TAG}
     platform: windows
     env_file:
     - ./pki/certs/server-certs.vars
@@ -25,7 +25,7 @@ services:
     - elasticsearch
 
   app:
-    image: cluedin/app
+    image: cluedin/app:${TAG}
     platform: linux
     entrypoint:
     - sh
@@ -51,7 +51,7 @@ services:
 
 # Dependencies
   neo4j:
-    image: cluedin/neo4j
+    image: cluedin/neo4j:${TAG}
     platform: linux
     environment:
     - NEO4J_AUTH=none
@@ -61,28 +61,14 @@ services:
     - "7687:7687"
 
   elasticsearch:
-    image: cluedin/elasticsearch
+    image: cluedin/elasticsearch:${TAG}
     platform: linux
     ports:
     - "9200:9200"
     - "9300:9300"
 
-  rabbitmq:
-    image: rabbitmq:3-management
-    platform: linux
-    ports:
-    - "5672:5672"
-    - "15672:15672"
-    hostname: cluedin-dev
-
-  redis:
-    image: redis:alpine
-    platform: linux
-    ports:
-    - "6379:6379"
-
   sqlserver:
-    image: cluedin/sqlserver
+    image: cluedin/sqlserver:${TAG}
     platform: linux
     command: ["sh","-c","echo '127.0.0.1 localhost'>> /etc/hosts; /init/init.sh"]
     mem_limit: 3G
@@ -92,7 +78,7 @@ services:
     - "1433:1433"
 
   openrefine:
-    image: cluedin/openrefine:v2.3
+    image: cluedin/openrefine:${TAG}
     entrypoint:
     - sh
     - -c
@@ -104,9 +90,24 @@ services:
     volumes:
     - ./config-files:/config
 
+  rabbitmq:
+    image: rabbitmq:3.7-management-alpine
+    platform: linux
+    ports:
+    - "5672:5672"
+    - "15672:15672"
+    hostname: cluedin-dev
+
+  redis:
+    image: redis:5.0-alpine
+    platform: linux
+    ports:
+    - "6379:6379"
+
+
 # Useful tools
   seq:
-    image: datalust/seq:latest
+    image: datalust/seq:5
     platform: linux
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,11 +74,13 @@ services:
     image: cluedin/sqlserver:${TAG}
     platform: linux
     command: ["sh","-c","echo '127.0.0.1 localhost'>> /etc/hosts; /init/init.sh"]
+    environment:
+    - MSSQL_DATA_DIR=/mssql-data
     mem_limit: 3G
-    extra_hosts:
-    - "localhost:127.0.0.1"
     ports:
     - "1433:1433"
+    volumes:
+    - sqlserver:/mssql-data
 
   openrefine:
     image: cluedin/openrefine:${TAG}
@@ -118,3 +120,6 @@ services:
     ports:
     - "3200:80"
     - "5341:5341"
+
+volumes:
+  sqlserver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
     ports:
     - "7474:7474"
     - "7687:7687"
+    volumes:
+    - neo4j:/data
 
   elasticsearch:
     image: cluedin/elasticsearch:${TAG}
@@ -129,3 +131,4 @@ services:
 volumes:
   sqlserver:
   elasticsearch:
+  neo4j:

--- a/var-files/server.vars
+++ b/var-files/server.vars
@@ -30,3 +30,4 @@ AuthReturnUrl=https://auth.127.0.0.1.xip.io
 WebhookReturnUrl=https://webbhook.127.0.0.1.xip.io
 Feature.Clean.BaseUrl=http://openrefine:3333
 Domain=127.0.0.1.xip.io
+SeqUrl=http://seq:5341


### PR DESCRIPTION
Allows providing either DLLs or a list of nuget packages on a folder to copy onto the cluedin server (see README)

Also adds persistence to sqlserver (and follows the same pattern with neo4j and elasticsearch)

Fixes rabbitmq access (as guest log in was only allowed from localhost)

**REQUIRES https://github.com/CluedIn-io/CluedIn/pull/1099**